### PR TITLE
Fix for Issue #4

### DIFF
--- a/lib/manservant/man_page.rb
+++ b/lib/manservant/man_page.rb
@@ -61,7 +61,7 @@ module Manservant
 
     def defaults
       {
-        :man2html_path => `command -v man2html`,
+        :man2html_path => `which man2html`,
         :man2html_args => {
           :bare => true,
           :topm => 0


### PR DESCRIPTION
`command` is a bash builtin and ruby backticks (I'm assuming because $EDITOR is not set or something) is spawning with `/bin/sh`. `which` is more portable
