### PR TITLE
Cli integration

### DIFF
--- a/bin/manservant.sh
+++ b/bin/manservant.sh
@@ -10,9 +10,16 @@
 # from the command line, such that one could type 'man tmux', and go straight
 # to the browser
 
-# This will only support OSX for the moment, until I find the right "open browser"
-# cli call for other OSes
+# This will only support OSX and some linux distros, given that it relies on 
+# 'open' or 'xdg-open'
 
 MANSERVANT_HOST="http://man.dev"
 
-open "$MANSERVANT_HOST/$1"
+# OS Detection
+if [[ "$unamestr" == 'Darwin' ]]; then
+    open "$MANSERVANT_HOST/$1"
+elif [[ "$unamestr" == 'Linux' ]]; then
+    # Pipe the stdout/err out of the way. 
+    xdg-open "$MANSERVANT_HOST/$1" &> /dev/null &
+fi
+    

--- a/bin/manservant.sh
+++ b/bin/manservant.sh
@@ -13,7 +13,9 @@
 # This will only support OSX and some linux distros, given that it relies on 
 # 'open' or 'xdg-open'
 
-MANSERVANT_HOST="http://man.dev"
+MANSERVANT_HOST="http://localhost:9292"
+
+unamestr=`uname`
 
 # OS Detection
 if [[ "$unamestr" == 'Darwin' ]]; then

--- a/bin/manservant.sh
+++ b/bin/manservant.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Command line invokation for manservant (https://github.com/jimeh/manservant)
+# @ Anand Gupta 2012
+
+# Manservant is a pretty way to view man pages in the browser, rendering them
+# in comfortable HTML. 
+
+# This script allows you to bring up the manservant version of any man page 
+# from the command line, such that one could type 'man tmux', and go straight
+# to the browser
+
+# This will only support OSX for the moment, until I find the right "open browser"
+# cli call for other OSes
+
+MANSERVANT_HOST="http://man.dev"
+
+open "$MANSERVANT_HOST/$1"


### PR DESCRIPTION
I've written a super simple script so you can pull open the manservant pages via command line. Not complicated, it just calls 'open' (on osx, xdg-open on linux) with the first arg, which brings up the default browser at the right manservant page. 

The idea here is that I can alias this script to 'man' and then when I habitually type "man sed" I get the browser. There's no install script to get to this stage of ease of use included in this pull request.

This is certainly not cross platform yet. It'll work on OSX, and on many linux distros, but not all...
