### PR TITLE
Fix capitalization

### DIFF
--- a/lib/manservant/server.rb
+++ b/lib/manservant/server.rb
@@ -20,7 +20,7 @@ module Manservant
       end
 
       def sanitize_name(name)
-        name.downcase.gsub(/[^a-z0-9\-_\.]/i, '')
+        name.gsub(/[^a-z0-9\-_\.]/i, '')
       end
 
       def find_page(name, section = nil)


### PR DESCRIPTION
The sanitization is too broad when it downcases every query. man is case-sensitive. One example is PlistBuddy, an OS X tool. It would 404 before and is now found with this patch.
