### PR TITLE
Get manservant working on an Ubuntu-derived Linux distro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor/

--- a/lib/manservant/man_page.rb
+++ b/lib/manservant/man_page.rb
@@ -93,8 +93,8 @@ module Manservant
           # overstrike (which seems to be the case with Linux's 'man' command)
           :sun => (RUBY_PLATFORM =~ /linux/) ? true : false,
         },
-        # this seems to be is required on Linux; 78 should be a reasonable
-        # default for any OS, given that the navigation is 96ex from the left
+        # seems to be required on Linux; 78 works pretty well on both Mac and
+        # Linux after bumping up the 'left' position of the navigation div
         :man_cols => 78
       }
     end

--- a/lib/manservant/server/public/css/style.css
+++ b/lib/manservant/server/public/css/style.css
@@ -4,7 +4,7 @@
 .man-navigation a,
 .man-error,
 .man-error p {
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace !important;
+  font-family: Menlo, Monaco, Consolas, "Ubuntu Mono", "Courier New", monospace !important;
 }
 
 .man-content h2 {
@@ -33,7 +33,7 @@
   display: block !important;
   position: fixed;
   top: 0;
-  left: 96ex;
+  left: 100ex;
   bottom: 0;
   width: 100%;
   padding: 38px 0 20px 14px;


### PR DESCRIPTION
You don't explicitly mention in your README that this is (or was) an **OS X-only tool**. I kind of inferred that from your recommending Pow, but also because the auto-generated navigation links didn't work right out of the box on an Ubuntu-derived distro (elementaryOS). I guess the manual pages end up with slightly different formatting with the GNU `*roff` utilities.

Now, hopefully, there's no need to fix the README. <tt>:)</tt>

If you'd like some kind of confirmation that it also works in RHEL/CentOS or Debian or something else (just to be thorough), I'm willing to test on a VM.

## From the commit log

- `man2html` needs the `-sun` option on Linux, because man page sections are formatted differently (with strikethrough font), and won't get turned into `<H2>`s otherwise

 - Linux's `man` also seems to need `COLUMNS` set in the environment, otherwise you get a man page that's waaay too wide, and runs into the navigation div; picked a reasonable default (78) that should work for any platform, but it can be specified in the constructor just like `:man2html_path` and the others

 - Checked both GNU/Linux and BSD versions of the `man` man page, and they both use `-S` for something else (architecture-specific manual "subsections"), so now just call `man` without the explicit "look in this section" option, which should hopefully work on all platforms (e.g., `man 3 setlocale`).